### PR TITLE
Update mas-kafka-cluster-large.yaml

### DIFF
--- a/kafka/kafka-resources/mas-kafka-cluster-large.yaml
+++ b/kafka/kafka-resources/mas-kafka-cluster-large.yaml
@@ -59,5 +59,4 @@ spec:
       size: 10Gi
       deleteClaim: true
   entityOperator:
-    topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
removed `topicOperator {}` due to bug in which it periodically delete the `__consumer_offsets` topic. See issue https://github.com/strimzi/strimzi-kafka-operator/issues/3586